### PR TITLE
add vector glare to season list

### DIFF
--- a/public/data/seasons.json
+++ b/public/data/seasons.json
@@ -145,5 +145,12 @@
     "year": 7,
     "season": 1,
     "accent": "#bf9f43"
-  } 
+  },
+  {
+    "id": 26,
+    "operation": "Vector Glare",
+    "year": 7,
+    "season": 2,
+    "accent": "#12ac27"
+  }
 ]


### PR DESCRIPTION
this will bring all modern clients up to date the next time they open. Operators are pending as there is no icon yet...